### PR TITLE
fix: correct French label for total cards

### DIFF
--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -75,7 +75,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onNavigate }) => {
                 <Package className="w-8 h-8 text-blue-400 mr-3" />
                 <div>
                   <div className="text-2xl font-bold text-white">{gameState.userCards.length}</div>
-                  <div className="text-gray-300 text-sm">Cartes Total</div>
+                  <div className="text-gray-300 text-sm">Cartes totales</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace "Cartes Total" with proper French phrasing "Cartes totales" on dashboard stats card

## Testing
- `npm run lint` *(fails: Filter is defined but never used, SortAsc is defined but never used, Unexpected lexical declaration in case block, Unexpected any, Unexpected any, index is defined but never used, mockUser is defined but never used)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68966aaaf8e48323baa8e2cf4355b256