### PR TITLE
fix lg card height class

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -33,7 +33,7 @@ export const Card: React.FC<CardProps> = ({
   const sizeClasses = {
     sm: 'w-32 h-44',
     md: 'w-40 h-56',
-    lg: 'w-48 h-68'
+    lg: 'w-48 h-72'
   };
 
   return (


### PR DESCRIPTION
## Summary
- use valid Tailwind class `h-72` for large cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 errors in existing files)*
- `npm run build`

## Notes
- Manual visual verification of `lg` card height was not possible in the headless environment.

------
https://chatgpt.com/codex/tasks/task_e_68966a8250e483238a413bda62ae5136