### PR TITLE
refactor: add GameState context provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,20 @@ import { Dashboard } from './components/pages/Dashboard';
 import { PacksPage } from './components/pages/PacksPage';
 import { ShopPage } from './components/pages/ShopPage';
 import { MarketplacePage } from './components/pages/MarketplacePage';
-import { useGameState } from './hooks/useGameState';
+import { GameStateProvider } from './context/GameStateContext';
+import { useGameStateContext } from './hooks/useGameState';
 
 function App() {
+  return (
+    <GameStateProvider>
+      <AppContent />
+    </GameStateProvider>
+  );
+}
+
+const AppContent: React.FC = () => {
   const [currentPage, setCurrentPage] = useState('home');
-  const { gameState } = useGameState();
+  const { gameState } = useGameStateContext();
 
   const handleNavigate = (page: string) => {
     setCurrentPage(page);
@@ -43,6 +52,6 @@ function App() {
       </main>
     </div>
   );
-}
+};
 
 export default App;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Zap, User, ShoppingBag, Home, Package, TrendingUp, LogOut } from 'lucide-react';
-import { useGameState } from '../../hooks/useGameState';
+import { useGameStateContext } from '../../hooks/useGameState';
 
 interface HeaderProps {
   currentPage: string;
@@ -8,7 +8,7 @@ interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
-  const { gameState, logout } = useGameState();
+  const { gameState, logout } = useGameStateContext();
 
   const navItems = [
     { id: 'home', label: 'Accueil', icon: Home },

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Search, Filter, SortAsc, Package, TrendingUp, Zap, User } from 'lucide-react';
-import { useGameState } from '../../hooks/useGameState';
+import { Search, Package, TrendingUp, Zap, User } from 'lucide-react';
+import { useGameStateContext } from '../../hooks/useGameState';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { CardRarity, CardType } from '../../types';
@@ -10,7 +10,7 @@ interface DashboardProps {
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({ onNavigate }) => {
-  const { gameState } = useGameState();
+  const { gameState } = useGameStateContext();
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('name');
   const [filterRarity, setFilterRarity] = useState('all');
@@ -27,9 +27,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ onNavigate }) => {
       switch (sortBy) {
         case 'price':
           return b.price - a.price;
-        case 'rarity':
+        case 'rarity': {
           const rarityOrder = { common: 1, rare: 2, epic: 3, legendary: 4, mythic: 5 };
-          return rarityOrder[b.rarity as keyof typeof rarityOrder] - rarityOrder[a.rarity as keyof typeof rarityOrder];
+          return (
+            rarityOrder[b.rarity as keyof typeof rarityOrder] -
+            rarityOrder[a.rarity as keyof typeof rarityOrder]
+          );
+        }
         case 'date':
           return new Date(b.obtainedDate || 0).getTime() - new Date(a.obtainedDate || 0).getTime();
         default:

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Zap, Mail, Lock, User, ArrowRight } from 'lucide-react';
 import { Button } from '../ui/Button';
-import { useGameState } from '../../hooks/useGameState';
+import { useGameStateContext } from '../../hooks/useGameState';
 import { mockUser } from '../../data/mockData';
 
 interface LoginPageProps {
@@ -13,7 +13,7 @@ export const LoginPage: React.FC<LoginPageProps> = ({ onNavigate }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [username, setUsername] = useState('');
-  const { login } = useGameState();
+  const { login } = useGameStateContext();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/pages/MarketplacePage.tsx
+++ b/src/components/pages/MarketplacePage.tsx
@@ -1,20 +1,21 @@
 import React, { useState } from 'react';
 import { TrendingUp, Search, Filter, Zap } from 'lucide-react';
-import { useGameState } from '../../hooks/useGameState';
+import { useGameStateContext } from '../../hooks/useGameState';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { marketListings } from '../../data/mockData';
+import { MarketListing } from '../../types';
 
 interface MarketplacePageProps {
   onNavigate: (page: string) => void;
 }
 
 export const MarketplacePage: React.FC<MarketplacePageProps> = ({ onNavigate }) => {
-  const { gameState, updateSpeedCoins } = useGameState();
+  const { gameState, updateSpeedCoins } = useGameStateContext();
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('price_asc');
 
-  const handleBuyCard = (listing: any) => {
+  const handleBuyCard = (listing: MarketListing) => {
     if (gameState.speedCoins >= listing.price) {
       updateSpeedCoins(-listing.price);
       // Dans une vraie app, on ajouterait la carte à l'inventaire

--- a/src/components/pages/PacksPage.tsx
+++ b/src/components/pages/PacksPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Package, Zap, Star, Gift } from 'lucide-react';
-import { useGameState } from '../../hooks/useGameState';
+import { useGameStateContext } from '../../hooks/useGameState';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { availablePacks } from '../../data/mockData';
@@ -12,7 +12,7 @@ interface PacksPageProps {
 }
 
 export const PacksPage: React.FC<PacksPageProps> = ({ onNavigate }) => {
-  const { gameState, updateSpeedCoins, addCards } = useGameState();
+  const { gameState, updateSpeedCoins, addCards } = useGameStateContext();
   const [selectedPack, setSelectedPack] = useState<Pack | null>(null);
   const [openingPack, setOpeningPack] = useState(false);
   const [openedCards, setOpenedCards] = useState<CardType[]>([]);

--- a/src/components/pages/ShopPage.tsx
+++ b/src/components/pages/ShopPage.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { ShoppingBag, Clock, Zap, Star } from 'lucide-react';
-import { useGameState } from '../../hooks/useGameState';
+import { useGameStateContext } from '../../hooks/useGameState';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { dailyShopCards } from '../../data/mockData';
+import { Card as CardType } from '../../types';
 
 interface ShopPageProps {
   onNavigate: (page: string) => void;
 }
 
 export const ShopPage: React.FC<ShopPageProps> = ({ onNavigate }) => {
-  const { gameState, updateSpeedCoins, addCards } = useGameState();
+  const { gameState, updateSpeedCoins, addCards } = useGameStateContext();
 
-  const handleBuyCard = (card: any) => {
+  const handleBuyCard = (card: CardType) => {
     if (gameState.speedCoins >= card.price) {
       updateSpeedCoins(-card.price);
       addCards([{ ...card, obtainedDate: new Date() }]);
@@ -82,7 +83,7 @@ export const ShopPage: React.FC<ShopPageProps> = ({ onNavigate }) => {
           </div>
           
           <div className="grid md:grid-cols-3 gap-8">
-            {dailyShopCards.map((card, index) => {
+            {dailyShopCards.map((card) => {
               const canAfford = gameState.speedCoins >= card.price;
               
               return (

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -1,0 +1,85 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { GameState, User, Card } from '../types';
+import { sampleCards } from '../data/mockData';
+
+interface GameStateContextType {
+  gameState: GameState;
+  login: (user: User) => void;
+  logout: () => void;
+  updateSpeedCoins: (amount: number) => void;
+  addCards: (cards: Card[]) => void;
+  removeCard: (cardId: string) => void;
+}
+
+const GameStateContext = createContext<GameStateContextType | undefined>(undefined);
+
+export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [gameState, setGameState] = useState<GameState>({
+    user: null,
+    userCards: [],
+    speedCoins: 0,
+    isAuthenticated: false
+  });
+
+  useEffect(() => {
+    const savedState = localStorage.getItem('f1-game-state');
+    if (savedState) {
+      const parsed = JSON.parse(savedState);
+      setGameState(parsed);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('f1-game-state', JSON.stringify(gameState));
+  }, [gameState]);
+
+  const login = (user: User) => {
+    setGameState(prev => ({
+      ...prev,
+      user,
+      speedCoins: user.speedCoins,
+      userCards: sampleCards,
+      isAuthenticated: true
+    }));
+  };
+
+  const logout = () => {
+    setGameState({
+      user: null,
+      userCards: [],
+      speedCoins: 0,
+      isAuthenticated: false
+    });
+    localStorage.removeItem('f1-game-state');
+  };
+
+  const updateSpeedCoins = (amount: number) => {
+    setGameState(prev => ({
+      ...prev,
+      speedCoins: prev.speedCoins + amount,
+      user: prev.user ? { ...prev.user, speedCoins: prev.speedCoins + amount } : null
+    }));
+  };
+
+  const addCards = (cards: Card[]) => {
+    setGameState(prev => ({
+      ...prev,
+      userCards: [...prev.userCards, ...cards]
+    }));
+  };
+
+  const removeCard = (cardId: string) => {
+    setGameState(prev => ({
+      ...prev,
+      userCards: prev.userCards.filter(card => card.id !== cardId)
+    }));
+  };
+
+  return (
+    <GameStateContext.Provider value={{ gameState, login, logout, updateSpeedCoins, addCards, removeCard }}>
+      {children}
+    </GameStateContext.Provider>
+  );
+};
+
+export default GameStateContext;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,77 +1,10 @@
-import { useState, useEffect } from 'react';
-import { GameState, User, Card } from '../types';
-import { mockUser, sampleCards } from '../data/mockData';
+import { useContext } from 'react';
+import GameStateContext from '../context/GameStateContext';
 
-export const useGameState = () => {
-  const [gameState, setGameState] = useState<GameState>({
-    user: null,
-    userCards: [],
-    speedCoins: 0,
-    isAuthenticated: false
-  });
-
-  // Simulate loading saved state
-  useEffect(() => {
-    const savedState = localStorage.getItem('f1-game-state');
-    if (savedState) {
-      const parsed = JSON.parse(savedState);
-      setGameState(parsed);
-    }
-  }, []);
-
-  // Save state to localStorage
-  useEffect(() => {
-    localStorage.setItem('f1-game-state', JSON.stringify(gameState));
-  }, [gameState]);
-
-  const login = (user: User) => {
-    setGameState(prev => ({
-      ...prev,
-      user,
-      speedCoins: user.speedCoins,
-      userCards: sampleCards,
-      isAuthenticated: true
-    }));
-  };
-
-  const logout = () => {
-    setGameState({
-      user: null,
-      userCards: [],
-      speedCoins: 0,
-      isAuthenticated: false
-    });
-    localStorage.removeItem('f1-game-state');
-  };
-
-  const updateSpeedCoins = (amount: number) => {
-    setGameState(prev => ({
-      ...prev,
-      speedCoins: prev.speedCoins + amount,
-      user: prev.user ? { ...prev.user, speedCoins: prev.speedCoins + amount } : null
-    }));
-  };
-
-  const addCards = (cards: Card[]) => {
-    setGameState(prev => ({
-      ...prev,
-      userCards: [...prev.userCards, ...cards]
-    }));
-  };
-
-  const removeCard = (cardId: string) => {
-    setGameState(prev => ({
-      ...prev,
-      userCards: prev.userCards.filter(card => card.id !== cardId)
-    }));
-  };
-
-  return {
-    gameState,
-    login,
-    logout,
-    updateSpeedCoins,
-    addCards,
-    removeCard
-  };
+export const useGameStateContext = () => {
+  const context = useContext(GameStateContext);
+  if (!context) {
+    throw new Error('useGameStateContext must be used within a GameStateProvider');
+  }
+  return context;
 };


### PR DESCRIPTION
## Summary
- add GameStateContext provider to share game state across app
- expose useGameStateContext hook and update components to consume it
- wrap App with GameStateProvider

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68966a71b0b48323ae1c5017e9a8c834