### PR TITLE
Add Vitest setup and card generation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # F1-Card-Collection
 Jeu de carte F1
+
+## Tests
+
+Pour lancer la suite de tests :
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -28,6 +29,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/tests/cardGeneration.test.ts
+++ b/tests/cardGeneration.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateRandomCard, openPack } from '../src/utils/cardGeneration';
+import { CardRarity, CardType, PackType } from '../src/types';
+
+describe('generateRandomCard', () => {
+  it('génère une carte valide', () => {
+    const card = generateRandomCard(PackType.BASIC);
+
+    expect(typeof card.id).toBe('string');
+    expect(typeof card.name).toBe('string');
+    expect(Object.values(CardType)).toContain(card.type);
+    expect(Object.values(CardRarity)).toContain(card.rarity);
+    expect(typeof card.price).toBe('number');
+  });
+});
+
+describe('openPack', () => {
+  it('retourne le nombre correct de cartes', () => {
+    const cards = openPack(PackType.BASIC, 5);
+    expect(cards).toHaveLength(5);
+  });
+});
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary
- add Vitest to dev dependencies and npm test script
- cover card generation utilities with basic tests
- document how to run tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68966b003d608323aa3198362ebe6da6