### PR TITLE
feat: add react router for navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,48 +1,8 @@
-import React, { useState } from 'react';
-import { Header } from './components/layout/Header';
-import { HomePage } from './components/pages/HomePage';
-import { LoginPage } from './components/pages/LoginPage';
-import { Dashboard } from './components/pages/Dashboard';
-import { PacksPage } from './components/pages/PacksPage';
-import { ShopPage } from './components/pages/ShopPage';
-import { MarketplacePage } from './components/pages/MarketplacePage';
-import { useGameState } from './hooks/useGameState';
+import React from 'react';
+import AppRouter from './router';
 
 function App() {
-  const [currentPage, setCurrentPage] = useState('home');
-  const { gameState } = useGameState();
-
-  const handleNavigate = (page: string) => {
-    setCurrentPage(page);
-  };
-
-  const renderPage = () => {
-    switch (currentPage) {
-      case 'home':
-        return <HomePage onNavigate={handleNavigate} isAuthenticated={gameState.isAuthenticated} />;
-      case 'login':
-        return <LoginPage onNavigate={handleNavigate} />;
-      case 'dashboard':
-        return <Dashboard onNavigate={handleNavigate} />;
-      case 'packs':
-        return <PacksPage onNavigate={handleNavigate} />;
-      case 'shop':
-        return <ShopPage onNavigate={handleNavigate} />;
-      case 'marketplace':
-        return <MarketplacePage onNavigate={handleNavigate} />;
-      default:
-        return <HomePage onNavigate={handleNavigate} isAuthenticated={gameState.isAuthenticated} />;
-    }
-  };
-
-  return (
-    <div className="min-h-screen bg-black">
-      <Header currentPage={currentPage} onNavigate={handleNavigate} />
-      <main>
-        {renderPage()}
-      </main>
-    </div>
-  );
+  return <AppRouter />;
 }
 
 export default App;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
 import { Zap, User, ShoppingBag, Home, Package, TrendingUp, LogOut } from 'lucide-react';
+import { Link, NavLink } from 'react-router-dom';
 import { useGameState } from '../../hooks/useGameState';
 
-interface HeaderProps {
-  currentPage: string;
-  onNavigate: (page: string) => void;
-}
-
-export const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
+export const Header: React.FC = () => {
   const { gameState, logout } = useGameState();
 
   const navItems = [
-    { id: 'home', label: 'Accueil', icon: Home },
-    { id: 'dashboard', label: 'Collection', icon: User },
-    { id: 'shop', label: 'Boutique', icon: ShoppingBag },
-    { id: 'marketplace', label: 'Marché', icon: TrendingUp },
-    { id: 'packs', label: 'Packs', icon: Package }
+    { to: '/', label: 'Accueil', icon: Home },
+    { to: '/dashboard', label: 'Collection', icon: User },
+    { to: '/shop', label: 'Boutique', icon: ShoppingBag },
+    { to: '/marketplace', label: 'Marché', icon: TrendingUp },
+    { to: '/packs', label: 'Packs', icon: Package }
   ];
 
   return (
@@ -36,18 +32,20 @@ export const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
               {navItems.map((item) => {
                 const Icon = item.icon;
                 return (
-                  <button
-                    key={item.id}
-                    onClick={() => onNavigate(item.id)}
-                    className={`flex items-center px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
-                      currentPage === item.id
-                        ? 'bg-red-600 text-white shadow-lg'
-                        : 'text-gray-300 hover:text-white hover:bg-red-700/50'
-                    }`}
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    className={({ isActive }) =>
+                      `flex items-center px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                        isActive
+                          ? 'bg-red-600 text-white shadow-lg'
+                          : 'text-gray-300 hover:text-white hover:bg-red-700/50'
+                      }`
+                    }
                   >
                     <Icon className="w-4 h-4 mr-2" />
                     {item.label}
-                  </button>
+                  </NavLink>
                 );
               })}
             </nav>
@@ -60,12 +58,12 @@ export const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
                   <Zap className="w-4 h-4 mr-1" />
                   <span>{gameState.speedCoins.toLocaleString()} SC</span>
                 </div>
-                
+
                 <div className="flex items-center text-white">
                   <User className="w-5 h-5 mr-2" />
                   <span className="font-medium">{gameState.user?.username}</span>
                 </div>
-                
+
                 <button
                   onClick={logout}
                   className="text-gray-300 hover:text-white p-2 rounded-lg hover:bg-red-700/50 transition-colors"
@@ -75,12 +73,12 @@ export const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
                 </button>
               </>
             ) : (
-              <button
-                onClick={() => onNavigate('login')}
+              <Link
+                to="/login"
                 className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
               >
                 Connexion
-              </button>
+              </Link>
             )}
           </div>
         </div>
@@ -91,18 +89,20 @@ export const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
             {navItems.map((item) => {
               const Icon = item.icon;
               return (
-                <button
-                  key={item.id}
-                  onClick={() => onNavigate(item.id)}
-                  className={`flex items-center px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition-all duration-200 ${
-                    currentPage === item.id
-                      ? 'bg-red-600 text-white'
-                      : 'text-gray-300 hover:text-white hover:bg-red-700/50'
-                  }`}
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    `flex items-center px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition-all duration-200 ${
+                      isActive
+                        ? 'bg-red-600 text-white'
+                        : 'text-gray-300 hover:text-white hover:bg-red-700/50'
+                    }`
+                  }
                 >
                   <Icon className="w-3 h-3 mr-1" />
                   {item.label}
-                </button>
+                </NavLink>
               );
             })}
           </nav>

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import { Search, Filter, SortAsc, Package, TrendingUp, Zap, User } from 'lucide-react';
+import { useNavigate } from "react-router-dom";
 import { useGameState } from '../../hooks/useGameState';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { CardRarity, CardType } from '../../types';
 
-interface DashboardProps {
-  onNavigate: (page: string) => void;
-}
 
-export const Dashboard: React.FC<DashboardProps> = ({ onNavigate }) => {
+export const Dashboard: React.FC = () => {
+  const navigate = useNavigate();
   const { gameState } = useGameState();
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('name');
@@ -49,7 +48,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onNavigate }) => {
         <div className="text-center">
           <h2 className="text-3xl font-bold text-white mb-4">Accès restreint</h2>
           <p className="text-gray-300 mb-8">Connectez-vous pour accéder à votre collection</p>
-          <Button onClick={() => onNavigate('login')}>Se connecter</Button>
+          <Button onClick={() => navigate('/login')}>Se connecter</Button>
         </div>
       </div>
     );
@@ -184,7 +183,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onNavigate }) => {
                 ? 'Essayez de modifier vos filtres'
                 : 'Commencez par acheter quelques packs !'}
             </p>
-            <Button onClick={() => onNavigate('packs')}>
+            <Button onClick={() => navigate('/packs')}>
               Acheter des Packs
             </Button>
           </div>

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Zap, Trophy, Users, TrendingUp, Package, Star } from 'lucide-react';
+import { useNavigate } from "react-router-dom";
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { dailyShopCards } from '../../data/mockData';
 
 interface HomePageProps {
-  onNavigate: (page: string) => void;
   isAuthenticated: boolean;
 }
 
-export const HomePage: React.FC<HomePageProps> = ({ onNavigate, isAuthenticated }) => {
+export const HomePage: React.FC<HomePageProps> = ({ isAuthenticated }) => {
+  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-red-900">
       {/* Hero Section */}
@@ -36,15 +37,15 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate, isAuthenticated 
             
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               {isAuthenticated ? (
-                <Button size="lg" onClick={() => onNavigate('dashboard')}>
+                <Button size="lg" onClick={() => navigate('/dashboard')}>
                   Voir ma Collection
                 </Button>
               ) : (
-                <Button size="lg" onClick={() => onNavigate('login')}>
+                <Button size="lg" onClick={() => navigate('/login')}>
                   Commencer l'Aventure
                 </Button>
               )}
-              <Button variant="outline" size="lg" onClick={() => onNavigate('shop')}>
+              <Button variant="outline" size="lg" onClick={() => navigate('/shop')}>
                 Explorer la Boutique
               </Button>
             </div>
@@ -114,7 +115,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate, isAuthenticated 
           </div>
           
           <div className="text-center">
-            <Button size="lg" onClick={() => onNavigate('shop')}>
+            <Button size="lg" onClick={() => navigate('/shop')}>
               <Package className="w-5 h-5 mr-2" />
               Voir toute la Boutique
             </Button>
@@ -158,11 +159,11 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate, isAuthenticated 
               Rejoignez des milliers de passionnés et construisez la collection F1 ultime !
             </p>
             {isAuthenticated ? (
-              <Button size="lg" onClick={() => onNavigate('packs')}>
+              <Button size="lg" onClick={() => navigate('/packs')}>
                 Ouvrir votre premier Pack
               </Button>
             ) : (
-              <Button size="lg" onClick={() => onNavigate('login')}>
+              <Button size="lg" onClick={() => navigate('/login')}>
                 Créer un Compte Gratuit
               </Button>
             )}

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { Zap, Mail, Lock, User, ArrowRight } from 'lucide-react';
+import { useNavigate } from "react-router-dom";
 import { Button } from '../ui/Button';
 import { useGameState } from '../../hooks/useGameState';
 import { mockUser } from '../../data/mockData';
 
-interface LoginPageProps {
-  onNavigate: (page: string) => void;
-}
 
-export const LoginPage: React.FC<LoginPageProps> = ({ onNavigate }) => {
+export const LoginPage: React.FC = () => {
+  const navigate = useNavigate();
   const [isLogin, setIsLogin] = useState(true);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -26,7 +25,7 @@ export const LoginPage: React.FC<LoginPageProps> = ({ onNavigate }) => {
     };
     
     login(user);
-    onNavigate('dashboard');
+    navigate('/dashboard');
   };
 
   return (

--- a/src/components/pages/MarketplacePage.tsx
+++ b/src/components/pages/MarketplacePage.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import { TrendingUp, Search, Filter, Zap } from 'lucide-react';
+import { useNavigate } from "react-router-dom";
 import { useGameState } from '../../hooks/useGameState';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { marketListings } from '../../data/mockData';
 
-interface MarketplacePageProps {
-  onNavigate: (page: string) => void;
-}
 
-export const MarketplacePage: React.FC<MarketplacePageProps> = ({ onNavigate }) => {
+export const MarketplacePage: React.FC = () => {
+  const navigate = useNavigate();
   const { gameState, updateSpeedCoins } = useGameState();
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('price_asc');
@@ -45,7 +44,7 @@ export const MarketplacePage: React.FC<MarketplacePageProps> = ({ onNavigate }) 
         <div className="text-center">
           <h2 className="text-3xl font-bold text-white mb-4">Accès restreint</h2>
           <p className="text-gray-300 mb-8">Connectez-vous pour accéder au marché</p>
-          <Button onClick={() => onNavigate('login')}>Se connecter</Button>
+          <Button onClick={() => navigate('/login')}>Se connecter</Button>
         </div>
       </div>
     );
@@ -170,7 +169,7 @@ export const MarketplacePage: React.FC<MarketplacePageProps> = ({ onNavigate }) 
           </p>
           
           <div className="text-center">
-            <Button onClick={() => onNavigate('dashboard')} variant="secondary">
+            <Button onClick={() => navigate('/dashboard')} variant="secondary">
               Accéder à ma Collection
             </Button>
           </div>

--- a/src/components/pages/PacksPage.tsx
+++ b/src/components/pages/PacksPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Package, Zap, Star, Gift } from 'lucide-react';
+import { useNavigate } from "react-router-dom";
 import { useGameState } from '../../hooks/useGameState';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
@@ -7,11 +8,9 @@ import { availablePacks } from '../../data/mockData';
 import { openPack } from '../../utils/cardGeneration';
 import { Pack, Card as CardType } from '../../types';
 
-interface PacksPageProps {
-  onNavigate: (page: string) => void;
-}
 
-export const PacksPage: React.FC<PacksPageProps> = ({ onNavigate }) => {
+export const PacksPage: React.FC = () => {
+  const navigate = useNavigate();
   const { gameState, updateSpeedCoins, addCards } = useGameState();
   const [selectedPack, setSelectedPack] = useState<Pack | null>(null);
   const [openingPack, setOpeningPack] = useState(false);
@@ -47,7 +46,7 @@ export const PacksPage: React.FC<PacksPageProps> = ({ onNavigate }) => {
         <div className="text-center">
           <h2 className="text-3xl font-bold text-white mb-4">Accès restreint</h2>
           <p className="text-gray-300 mb-8">Connectez-vous pour acheter des packs</p>
-          <Button onClick={() => onNavigate('login')}>Se connecter</Button>
+          <Button onClick={() => navigate('/login')}>Se connecter</Button>
         </div>
       </div>
     );
@@ -112,7 +111,7 @@ export const PacksPage: React.FC<PacksPageProps> = ({ onNavigate }) => {
             <Button onClick={handleCloseResult}>
               Continuer
             </Button>
-            <Button variant="secondary" onClick={() => onNavigate('dashboard')}>
+            <Button variant="secondary" onClick={() => navigate('/dashboard')}>
               Voir ma Collection
             </Button>
           </div>

--- a/src/components/pages/ShopPage.tsx
+++ b/src/components/pages/ShopPage.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { ShoppingBag, Clock, Zap, Star } from 'lucide-react';
+import { useNavigate } from "react-router-dom";
 import { useGameState } from '../../hooks/useGameState';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { dailyShopCards } from '../../data/mockData';
 
-interface ShopPageProps {
-  onNavigate: (page: string) => void;
-}
 
-export const ShopPage: React.FC<ShopPageProps> = ({ onNavigate }) => {
+export const ShopPage: React.FC = () => {
+  const navigate = useNavigate();
   const { gameState, updateSpeedCoins, addCards } = useGameState();
 
   const handleBuyCard = (card: any) => {
@@ -39,7 +38,7 @@ export const ShopPage: React.FC<ShopPageProps> = ({ onNavigate }) => {
         <div className="text-center">
           <h2 className="text-3xl font-bold text-white mb-4">Accès restreint</h2>
           <p className="text-gray-300 mb-8">Connectez-vous pour accéder à la boutique</p>
-          <Button onClick={() => onNavigate('login')}>Se connecter</Button>
+          <Button onClick={() => navigate('/login')}>Se connecter</Button>
         </div>
       </div>
     );
@@ -125,7 +124,7 @@ export const ShopPage: React.FC<ShopPageProps> = ({ onNavigate }) => {
         {/* Navigation Cards */}
         <div className="grid md:grid-cols-2 gap-8">
           <div className="bg-gradient-to-br from-red-600/20 to-red-800/20 border border-red-500/30 rounded-2xl p-8 hover:from-red-600/30 hover:to-red-800/30 transition-all duration-300 cursor-pointer"
-               onClick={() => onNavigate('packs')}>
+               onClick={() => navigate('/packs')}>
             <div className="text-center">
               <div className="w-16 h-16 bg-gradient-to-br from-red-500 to-red-700 rounded-xl flex items-center justify-center mx-auto mb-4">
                 <ShoppingBag className="text-white w-8 h-8" />
@@ -139,7 +138,7 @@ export const ShopPage: React.FC<ShopPageProps> = ({ onNavigate }) => {
           </div>
 
           <div className="bg-gradient-to-br from-green-600/20 to-green-800/20 border border-green-500/30 rounded-2xl p-8 hover:from-green-600/30 hover:to-green-800/30 transition-all duration-300 cursor-pointer"
-               onClick={() => onNavigate('marketplace')}>
+               onClick={() => navigate('/marketplace')}>
             <div className="text-center">
               <div className="w-16 h-16 bg-gradient-to-br from-green-500 to-green-700 rounded-xl flex items-center justify-center mx-auto mb-4">
                 <Star className="text-white w-8 h-8" />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Header } from './components/layout/Header';
+import { HomePage } from './components/pages/HomePage';
+import { LoginPage } from './components/pages/LoginPage';
+import { Dashboard } from './components/pages/Dashboard';
+import { PacksPage } from './components/pages/PacksPage';
+import { ShopPage } from './components/pages/ShopPage';
+import { MarketplacePage } from './components/pages/MarketplacePage';
+import { useGameState } from './hooks/useGameState';
+
+export const AppRouter: React.FC = () => {
+  const { gameState } = useGameState();
+
+  return (
+    <BrowserRouter>
+      <div className="min-h-screen bg-black">
+        <Header />
+        <main>
+          <Routes>
+            <Route path="/" element={<HomePage isAuthenticated={gameState.isAuthenticated} />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/packs" element={<PacksPage />} />
+            <Route path="/shop" element={<ShopPage />} />
+            <Route path="/marketplace" element={<MarketplacePage />} />
+          </Routes>
+        </main>
+      </div>
+    </BrowserRouter>
+  );
+};
+
+export default AppRouter;


### PR DESCRIPTION
## Summary
- add react-router-dom dependency
- replace currentPage logic with React Router routes
- convert header buttons to links and update pages for router navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom" - package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68966af930508323947ec5fc199e4134