### PR TITLE
feat: add card details page and navigation

### DIFF
--- a/src/components/pages/CardDetailsPage.tsx
+++ b/src/components/pages/CardDetailsPage.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { sampleCards, dailyShopCards, marketListings } from '../../data/mockData';
+import { Card as CardType } from '../../types';
+import { Button } from '../ui/Button';
+
+// Helper to gather all available cards (from mock data for now)
+const getAllCards = (): CardType[] => {
+  const marketCards = marketListings.map((listing) => listing.card);
+  return [...sampleCards, ...dailyShopCards, ...marketCards];
+};
+
+export const CardDetailsPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [card, setCard] = useState<CardType | null>(null);
+
+  useEffect(() => {
+    const fetchCard = async () => {
+      // In a real application this would be an API call
+      const allCards = getAllCards();
+      const found = allCards.find((c) => c.id === id) || null;
+      setCard(found);
+    };
+    fetchCard();
+  }, [id]);
+
+  if (!card) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-red-900 flex items-center justify-center px-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-white mb-4">Carte introuvable</h2>
+          <Button onClick={() => navigate('/dashboard')}>Retour à la collection</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-red-900 py-8 px-4">
+      <div className="max-w-5xl mx-auto">
+        <Button variant="outline" className="mb-6" onClick={() => navigate('/dashboard')}>
+          Retour à la collection
+        </Button>
+
+        <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl p-6 grid md:grid-cols-2 gap-6">
+          <img
+            src={card.imageUrl}
+            alt={card.name}
+            className="w-full h-72 object-cover rounded-lg"
+          />
+
+          <div className="flex flex-col">
+            <h1 className="text-3xl font-bold text-white mb-4">{card.name}</h1>
+            <p className="text-gray-300 mb-6">{card.description}</p>
+
+            <div className="mb-6">
+              <h2 className="text-xl font-semibold text-white mb-2">Stats</h2>
+              <ul className="text-gray-300 space-y-1 text-sm">
+                <li>Type : {card.type.toUpperCase()}</li>
+                <li>Rareté : {card.rarity.toUpperCase()}</li>
+                <li>Prix : {card.price.toLocaleString()} SC</li>
+              </ul>
+            </div>
+
+            <div>
+              <h2 className="text-xl font-semibold text-white mb-2">Historique</h2>
+              {card.obtainedDate ? (
+                <p className="text-gray-300 text-sm">
+                  Obtenue le {new Date(card.obtainedDate).toLocaleDateString()}
+                </p>
+              ) : (
+                <p className="text-gray-300 text-sm">Historique indisponible.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CardDetailsPage;
+

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card as CardType, CardRarity } from '../../types';
 
 interface CardProps {
@@ -30,16 +31,24 @@ export const Card: React.FC<CardProps> = ({
   showPrice = true,
   size = 'md'
 }) => {
+  const navigate = useNavigate();
   const sizeClasses = {
     sm: 'w-32 h-44',
     md: 'w-40 h-56',
     lg: 'w-48 h-72'
   };
 
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+    navigate(`/card/${card.id}`);
+  };
+
   return (
     <div
       className={`${sizeClasses[size]} bg-white rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 cursor-pointer transform hover:scale-105 ${rarityGlow[card.rarity]} border-2 border-transparent hover:border-red-300`}
-      onClick={onClick}
+      onClick={handleClick}
     >
       <div className={`h-3 rounded-t-xl bg-gradient-to-r ${rarityColors[card.rarity]}`} />
       

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,6 +7,7 @@ import { Dashboard } from './components/pages/Dashboard';
 import { PacksPage } from './components/pages/PacksPage';
 import { ShopPage } from './components/pages/ShopPage';
 import { MarketplacePage } from './components/pages/MarketplacePage';
+import { CardDetailsPage } from './components/pages/CardDetailsPage';
 
 export const AppRouter: React.FC = () => (
   <BrowserRouter>
@@ -18,6 +19,7 @@ export const AppRouter: React.FC = () => (
       <Route path="/packs" element={<PacksPage />} />
       <Route path="/shop" element={<ShopPage />} />
       <Route path="/marketplace" element={<MarketplacePage />} />
+      <Route path="/card/:id" element={<CardDetailsPage />} />
     </Routes>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- add `CardDetailsPage` to show card info and history
- navigate to details page when clicking a card
- register new card detail route

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading 'length'))*

------
https://chatgpt.com/codex/tasks/task_e_68988a5de4188323bb42c3e255f61bc6