### PR TITLE
feat: add achievements navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Zap, User, ShoppingBag, Home, Package, TrendingUp, LogOut } from 'lucide-react';
+import { Zap, User, ShoppingBag, Home, Package, TrendingUp, LogOut, Trophy } from 'lucide-react';
 import { NavLink, Link } from 'react-router-dom';
 import { useGameStateContext } from '../../hooks/useGameState';
 
@@ -11,7 +11,8 @@ export const Header: React.FC = () => {
     { id: 'dashboard', label: 'Collection', icon: User, path: '/dashboard' },
     { id: 'shop', label: 'Boutique', icon: ShoppingBag, path: '/shop' },
     { id: 'marketplace', label: 'Marché', icon: TrendingUp, path: '/marketplace' },
-    { id: 'packs', label: 'Packs', icon: Package, path: '/packs' }
+    { id: 'packs', label: 'Packs', icon: Package, path: '/packs' },
+    { id: 'achievements', label: 'Succès', icon: Trophy, path: '/achievements' }
   ];
 
   return (

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Search, Package, TrendingUp, Zap, User } from 'lucide-react';
+import { Search, Package, TrendingUp, Zap, User, Trophy } from 'lucide-react';
 import { useGameStateContext } from '../../hooks/useGameState';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
@@ -62,12 +62,22 @@ export const Dashboard: React.FC = () => {
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <div className="flex items-center mb-6">
-            <User className="w-8 h-8 text-red-400 mr-3" />
-            <div>
-              <h1 className="text-4xl font-bold text-white">Ma Collection</h1>
-              <p className="text-gray-300">Bienvenue, {gameState.user?.username} !</p>
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center">
+              <User className="w-8 h-8 text-red-400 mr-3" />
+              <div>
+                <h1 className="text-4xl font-bold text-white">Ma Collection</h1>
+                <p className="text-gray-300">Bienvenue, {gameState.user?.username} !</p>
+              </div>
             </div>
+            <Button
+              onClick={() => navigate('/achievements')}
+              variant="secondary"
+              className="flex items-center"
+            >
+              <Trophy className="w-4 h-4 mr-2" />
+              Succès
+            </Button>
           </div>
 
           {/* Stats Cards */}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import { PacksPage } from './components/pages/PacksPage';
 import { ShopPage } from './components/pages/ShopPage';
 import { MarketplacePage } from './components/pages/MarketplacePage';
 import { CardDetailsPage } from './components/pages/CardDetailsPage';
+import AchievementsPanel from './components/pages/AchievementsPanel';
 
 export const AppRouter: React.FC = () => (
   <BrowserRouter>
@@ -16,6 +17,7 @@ export const AppRouter: React.FC = () => (
       <Route path="/" element={<HomePage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/achievements" element={<AchievementsPanel />} />
       <Route path="/packs" element={<PacksPage />} />
       <Route path="/shop" element={<ShopPage />} />
       <Route path="/marketplace" element={<MarketplacePage />} />


### PR DESCRIPTION
## Summary
- add achievements page routing
- link achievements in header navigation
- add quick access to achievements from dashboard

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'length'))*

------
https://chatgpt.com/codex/tasks/task_e_68989891ac4c8323858b023b0d712dfd