### PR TITLE
Track achievement progress and first pack unlock

### DIFF
--- a/src/components/pages/PacksPage.tsx
+++ b/src/components/pages/PacksPage.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 
 export const PacksPage: React.FC = () => {
   const navigate = useNavigate();
-  const { gameState, updateSpeedCoins, addCards } = useGameStateContext();
+  const { gameState, updateSpeedCoins, addCards, unlockAchievement } = useGameStateContext();
   const [selectedPack, setSelectedPack] = useState<Pack | null>(null);
   const [openingPack, setOpeningPack] = useState(false);
   const [openedCards, setOpenedCards] = useState<CardType[]>([]);
@@ -27,6 +27,7 @@ export const PacksPage: React.FC = () => {
         setOpenedCards(cards);
         updateSpeedCoins(-pack.price);
         addCards(cards);
+        unlockAchievement('first_pack');
         setOpeningPack(false);
         setShowPackResult(true);
       }, 3000);

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -101,8 +101,27 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }));
   };
 
+  useEffect(() => {
+    const cardCount = gameState.userCards.length;
+    setAchievements(prev =>
+      prev.map(a =>
+        a.id === 'ten_cards'
+          ? {
+              ...a,
+              progress: Math.min((cardCount / 10) * 100, 100),
+              unlocked: a.unlocked || cardCount >= 10,
+            }
+          : a
+      )
+    );
+  }, [gameState.userCards.length]);
+
   const unlockAchievement = (id: string) => {
-    setAchievements(prev => prev.map(a => a.id === id ? { ...a, unlocked: true } : a));
+    setAchievements(prev =>
+      prev.map(a =>
+        a.id === id ? { ...a, progress: 100, unlocked: true } : a
+      )
+    );
   };
 
   return (


### PR DESCRIPTION
## Summary
- Unlock `first_pack` achievement when a pack is opened
- Track progress towards `ten_cards` and unlock at 10 cards
- Ensure achievements store both progress and unlocked state

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'length'))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989c1f039083239dd87643e71c2ea6