### PR TITLE
Award coins when unlocking achievements

### DIFF
--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -117,11 +117,14 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   }, [gameState.userCards.length]);
 
   const unlockAchievement = (id: string) => {
-    setAchievements(prev =>
-      prev.map(a =>
+    setAchievements(prev => {
+      const achievement = prev.find(a => a.id === id);
+      if (!achievement || achievement.unlocked) return prev;
+      updateSpeedCoins(achievement.reward);
+      return prev.map(a =>
         a.id === id ? { ...a, progress: 100, unlocked: true } : a
-      )
-    );
+      );
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- credit Speed Coins when an achievement is unlocked
- avoid duplicate rewards by checking the achievement's unlocked status

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989dfe84608323af7c9660d53a4fac