### PR TITLE
feat: add manual reward claiming for achievements

### DIFF
--- a/src/components/pages/AchievementsPanel.tsx
+++ b/src/components/pages/AchievementsPanel.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Trophy } from 'lucide-react';
 import { useGameStateContext } from '../../hooks/useGameState';
+import { Button } from '../ui/Button';
 
 const AchievementsPanel: React.FC = () => {
-  const { achievements } = useGameStateContext();
+  const { achievements, claimAchievementReward } = useGameStateContext();
 
   return (
     <div className="p-6 bg-black/20 rounded-lg border border-white/10">
@@ -13,21 +14,29 @@ const AchievementsPanel: React.FC = () => {
       </h2>
       <ul className="space-y-4">
         {achievements.map((ach) => (
-          <li key={ach.id} className="p-4 rounded-lg bg-white/5 border border-white/10">
-            <div className="flex justify-between items-center mb-2">
-              <div>
-                <p className="text-white font-semibold">{ach.description}</p>
-                <p className="text-gray-400 text-sm">{ach.criteria}</p>
+            <li key={ach.id} className="p-4 rounded-lg bg-white/5 border border-white/10">
+              <div className="flex justify-between items-center mb-2">
+                <div>
+                  <p className="text-white font-semibold">{ach.description}</p>
+                  <p className="text-gray-400 text-sm">{ach.criteria}</p>
+                </div>
+                {ach.unlocked ? (
+                  <Trophy className="w-6 h-6 text-yellow-400" />
+                ) : (
+                  <span className="text-gray-400 text-sm">{ach.progress}%</span>
+                )}
               </div>
-              {ach.unlocked ? (
-                <Trophy className="w-6 h-6 text-yellow-400" />
-              ) : (
-                <span className="text-gray-400 text-sm">{ach.progress}%</span>
+              <p className="text-green-400 text-sm">Récompense : {ach.reward} SC</p>
+              {ach.unlocked && !ach.rewardClaimed && (
+                <Button onClick={() => claimAchievementReward(ach.id)} size="sm" className="mt-2">
+                  Récupérer la récompense
+                </Button>
               )}
-            </div>
-            <p className="text-green-400 text-sm">Récompense : {ach.reward} SC</p>
-          </li>
-        ))}
+              {ach.unlocked && ach.rewardClaimed && (
+                <p className="text-green-400 text-sm mt-2">Récompense récupérée</p>
+              )}
+            </li>
+          ))}
         {achievements.length === 0 && (
           <li className="text-gray-400">Aucun succès disponible.</li>
         )}

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -8,6 +8,7 @@ export const defaultAchievements: Achievement[] = [
     reward: 100,
     progress: 0,
     unlocked: false,
+    rewardClaimed: false,
   },
   {
     id: 'ten_cards',
@@ -16,5 +17,6 @@ export const defaultAchievements: Achievement[] = [
     reward: 200,
     progress: 0,
     unlocked: false,
+    rewardClaimed: false,
   },
 ];

--- a/src/types/achievement.ts
+++ b/src/types/achievement.ts
@@ -5,4 +5,5 @@ export interface Achievement {
   reward: number;
   progress: number;
   unlocked: boolean;
+  rewardClaimed: boolean;
 }

--- a/src/utils/cardGeneration.ts
+++ b/src/utils/cardGeneration.ts
@@ -93,7 +93,7 @@ const selectRarityByWeight = (packType: PackType): CardRarity => {
 };
 
 const getRandomCardType = (): CardType => {
-  const types = Object.values(CardType);
+  const types = Object.keys(cardPool) as CardType[];
   return types[Math.floor(Math.random() * types.length)];
 };
 


### PR DESCRIPTION
## Summary
- add rewardClaimed tracking and claimAchievementReward handler
- expose a button to claim unlocked achievement rewards
- limit random card type generation to defined pools

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a9a65d7c8323b7c5f2b501365ef5