### PR TITLE
feat: add achievement completion popup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { GameStateProvider } from './context/GameStateContext';
 import AppRouter from './router';
+import AchievementToast from './components/ui/AchievementToast';
 
 function App() {
   return (
     <GameStateProvider>
       <AppRouter />
+      <AchievementToast />
     </GameStateProvider>
   );
 }

--- a/src/components/ui/AchievementToast.tsx
+++ b/src/components/ui/AchievementToast.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useGameStateContext } from '../../hooks/useGameState';
+import { Button } from './Button';
+
+const AchievementToast: React.FC = () => {
+  const { lastUnlockedAchievement, clearLastAchievement } = useGameStateContext();
+  const [visible, setVisible] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (lastUnlockedAchievement) {
+      setVisible(true);
+      const timer = setTimeout(() => {
+        setVisible(false);
+        clearLastAchievement();
+      }, 15000);
+      return () => clearTimeout(timer);
+    }
+  }, [lastUnlockedAchievement, clearLastAchievement]);
+
+  if (!visible || !lastUnlockedAchievement) return null;
+
+  const close = () => {
+    setVisible(false);
+    clearLastAchievement();
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-black/90 text-white p-4 rounded-lg shadow-lg w-72 relative">
+      <button onClick={close} className="absolute top-2 right-2 text-gray-300 hover:text-white">
+        <X size={16} />
+      </button>
+      <p className="font-bold mb-1">Objectif atteint ✅</p>
+      <p className="mb-3">{lastUnlockedAchievement.description}</p>
+      <Button size="sm" onClick={() => { navigate('/achievements'); close(); }}>
+        Voir les succès
+      </Button>
+    </div>
+  );
+};
+
+export default AchievementToast;


### PR DESCRIPTION
## Summary
- show bottom-right popup when an achievement unlocks
- auto-dismiss popup after 15s with link to achievements page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b866a1388323b02d347d83cded91