### PR TITLE
Fix router context for AchievementToast and add JSON parse safety

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { GameStateProvider } from './context/GameStateContext';
 import AppRouter from './router';
-import AchievementToast from './components/ui/AchievementToast';
 
 function App() {
   return (
     <GameStateProvider>
       <AppRouter />
-      <AchievementToast />
     </GameStateProvider>
   );
 }

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -41,18 +41,30 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   useEffect(() => {
     const savedState = localStorage.getItem('f1-game-state');
     if (savedState) {
-      const parsed = JSON.parse(savedState);
-      setGameState({ packsOpened: 0, cardsPurchased: 0, ...parsed });
+      try {
+        const parsed = JSON.parse(savedState);
+        setGameState({ packsOpened: 0, cardsPurchased: 0, ...parsed });
+      } catch (error) {
+        console.error('Failed to parse saved game state', error);
+      }
     }
     const savedAchievements = localStorage.getItem('f1-achievements');
     if (savedAchievements) {
-      const parsedAchievements: Achievement[] = JSON.parse(savedAchievements);
-      setAchievements(parsedAchievements.map(a => ({ rewardClaimed: false, ...a })));
+      try {
+        const parsedAchievements: Achievement[] = JSON.parse(savedAchievements);
+        setAchievements(parsedAchievements.map(a => ({ rewardClaimed: false, ...a })));
+      } catch (error) {
+        console.error('Failed to parse achievements', error);
+      }
     }
     const savedDaily = localStorage.getItem('f1-daily-achievements');
     if (savedDaily) {
-      const parsedDaily: Achievement[] = JSON.parse(savedDaily);
-      setDailyAchievements(parsedDaily.map(a => ({ rewardClaimed: false, ...a })));
+      try {
+        const parsedDaily: Achievement[] = JSON.parse(savedDaily);
+        setDailyAchievements(parsedDaily.map(a => ({ rewardClaimed: false, ...a })));
+      } catch (error) {
+        console.error('Failed to parse daily achievements', error);
+      }
     }
   }, []);
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import { ShopPage } from './components/pages/ShopPage';
 import { MarketplacePage } from './components/pages/MarketplacePage';
 import { CardDetailsPage } from './components/pages/CardDetailsPage';
 import AchievementsPanel from './components/pages/AchievementsPanel';
+import AchievementToast from './components/ui/AchievementToast';
 
 export const AppRouter: React.FC = () => (
   <BrowserRouter>
@@ -23,6 +24,7 @@ export const AppRouter: React.FC = () => (
       <Route path="/marketplace" element={<MarketplacePage />} />
       <Route path="/card/:id" element={<CardDetailsPage />} />
     </Routes>
+    <AchievementToast />
   </BrowserRouter>
 );
 


### PR DESCRIPTION
## Summary
- Render AchievementToast inside the router so useNavigate works
- Guard GameStateContext JSON.parse calls with try/catch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898be55ffe08323b097d0772bdfaf6d