### PR TITLE
Fix achievement toast positioning

### DIFF
--- a/src/components/ui/AchievementToast.tsx
+++ b/src/components/ui/AchievementToast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useGameStateContext } from '../../hooks/useGameState';
@@ -27,8 +28,8 @@ const AchievementToast: React.FC = () => {
     clearLastAchievement();
   };
 
-  return (
-    <div className="fixed bottom-4 right-4 bg-black/90 text-white p-4 rounded-lg shadow-lg w-72 relative">
+  return createPortal(
+    <div className="fixed top-4 right-4 bg-black/90 text-white p-4 rounded-lg shadow-lg w-72 relative">
       <button onClick={close} className="absolute top-2 right-2 text-gray-300 hover:text-white">
         <X size={16} />
       </button>
@@ -37,7 +38,8 @@ const AchievementToast: React.FC = () => {
       <Button size="sm" onClick={() => { navigate('/achievements'); close(); }}>
         Voir les succès
       </Button>
-    </div>
+    </div>,
+    document.body
   );
 };
 


### PR DESCRIPTION
## Summary
- Render achievement toast in a portal to document.body
- Keep toast fixed to top-right of the screen regardless of page scroll

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898c544b5748323ac507b1a0215ff74