### PR TITLE
Move achievement toast to top right

### DIFF
--- a/src/components/ui/AchievementToast.tsx
+++ b/src/components/ui/AchievementToast.tsx
@@ -29,7 +29,7 @@ const AchievementToast: React.FC = () => {
   };
 
   return createPortal(
-    <div className="fixed bottom-4 right-4 bg-black/90 text-white p-4 rounded-lg shadow-lg w-72 relative">
+    <div className="fixed top-4 right-4 bg-black/90 text-white p-4 rounded-lg shadow-lg w-72 relative">
       <button onClick={close} className="absolute top-2 right-2 text-gray-300 hover:text-white">
         <X size={16} />
       </button>


### PR DESCRIPTION
## Summary
- display achievement toast at the top-right corner of the page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d09e71e08323b504ab732f31514a