### PR TITLE
Add authentication backend and integrate login flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+data.sqlite

--- a/package.json
+++ b/package.json
@@ -8,13 +8,18 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "express": "^4.19.2",
+    "better-sqlite3": "^9.4.1",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,79 @@
+import express from 'express';
+import Database from 'better-sqlite3';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+app.use(express.json());
+
+const db = new Database('data.sqlite');
+
+db.exec(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE,
+  email TEXT UNIQUE,
+  password TEXT NOT NULL,
+  speedCoins INTEGER DEFAULT 0,
+  registrationDate TEXT
+)`);
+
+const JWT_SECRET = process.env.JWT_SECRET || 'changeme';
+
+app.post('/api/register', async (req, res) => {
+  const { username, email, password } = req.body;
+  if (!username || !email || !password) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+  try {
+    const existing = db.prepare('SELECT id FROM users WHERE email = ? OR username = ?').get(email, username);
+    if (existing) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const registrationDate = new Date().toISOString();
+    const stmt = db.prepare('INSERT INTO users (username, email, password, speedCoins, registrationDate) VALUES (?, ?, ?, ?, ?)');
+    const info = stmt.run(username, email, hashed, 0, registrationDate);
+    const user = { id: String(info.lastInsertRowid), username, email, speedCoins: 0, registrationDate };
+    const token = jwt.sign({ id: user.id }, JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token, user });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+  try {
+    const row = db.prepare('SELECT * FROM users WHERE email = ?').get(email);
+    if (!row) {
+      return res.status(400).json({ message: 'Invalid credentials' });
+    }
+    const valid = await bcrypt.compare(password, row.password);
+    if (!valid) {
+      return res.status(400).json({ message: 'Invalid credentials' });
+    }
+    const user = {
+      id: String(row.id),
+      username: row.username,
+      email: row.email,
+      speedCoins: row.speedCoins,
+      registrationDate: row.registrationDate
+    };
+    const token = jwt.sign({ id: user.id }, JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token, user });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+export default app;

--- a/src/components/pages/CardDetailsPage.tsx
+++ b/src/components/pages/CardDetailsPage.tsx
@@ -72,7 +72,7 @@ export const CardDetailsPage: React.FC = () => {
               <ul className="text-gray-300 space-y-1 text-sm">
                 <li>Type de carte : Pilote F1</li>
                 <li>Rareté : Légendaire</li>
-                <li>Valeur : 15 000</li>
+                <li>Valeur : 15 000</li>
               </ul>
             </div>
 

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Zap, Mail, Lock, User, ArrowRight } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { useGameStateContext } from '../../hooks/useGameState';
-import { mockUser } from '../../data/mockData';
 import { useNavigate } from 'react-router-dom';
+import { User as GameUser } from '../../types';
 
 export const LoginPage: React.FC = () => {
   const [isLogin, setIsLogin] = useState(true);
@@ -13,18 +13,30 @@ export const LoginPage: React.FC = () => {
   const { login } = useGameStateContext();
   const navigate = useNavigate();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  interface AuthResponse {
+    user: GameUser;
+    token: string;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    // Simulation de l'authentification
-    const user = {
-      ...mockUser,
-      email: email || mockUser.email,
-      username: username || mockUser.username
-    };
-    
-    login(user);
-    navigate('/dashboard');
+    const endpoint = isLogin ? '/api/login' : '/api/register';
+    const payload = isLogin
+      ? { email, password }
+      : { email, password, username };
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error('Authentication failed');
+      const data: AuthResponse = await res.json();
+      login(data);
+      navigate('/dashboard');
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -8,7 +8,7 @@ interface GameStateContextType {
   gameState: GameState;
   achievements: Achievement[];
   dailyAchievements: Achievement[];
-  login: (user: User) => void;
+  login: (data: { user: User; token: string }) => void;
   logout: () => void;
   updateSpeedCoins: (amount: number) => void;
   addCards: (cards: Card[]) => void;
@@ -31,7 +31,8 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     speedCoins: 0,
     packsOpened: 0,
     cardsPurchased: 0,
-    isAuthenticated: false
+    isAuthenticated: false,
+    token: null
   });
   const [achievements, setAchievements] = useState<Achievement[]>(defaultAchievements);
   const [dailyAchievements, setDailyAchievements] = useState<Achievement[]>(defaultDailyAchievements);
@@ -112,7 +113,8 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   }, [resetDailyChallenges]);
 
-  const login = (user: User) => {
+  const login = ({ user, token }: { user: User; token: string }) => {
+    localStorage.setItem('authToken', token);
     setGameState(prev => ({
       ...prev,
       user,
@@ -120,7 +122,8 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       userCards: sampleCards,
       packsOpened: 0,
       cardsPurchased: 0,
-      isAuthenticated: true
+      isAuthenticated: true,
+      token
     }));
   };
 
@@ -131,9 +134,11 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       speedCoins: 0,
       packsOpened: 0,
       cardsPurchased: 0,
-      isAuthenticated: false
+      isAuthenticated: false,
+      token: null
     });
     localStorage.removeItem('f1-game-state');
+    localStorage.removeItem('authToken');
   };
 
   const updateSpeedCoins = (amount: number) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,7 @@ export interface GameState {
   packsOpened: number;
   cardsPurchased: number;
   isAuthenticated: boolean;
+  token: string | null;
 }
 
 export * from './achievement';


### PR DESCRIPTION
## Summary
- implement Express server with SQLite for user registration and login
- hook Login page into /api/register and /api/login endpoints
- store auth token in game state and localStorage for persistent sessions
- fix lint error in CardDetailsPage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e4ca34c08323bcb475f69a07a877