### PR TITLE
Enable CORS and dev proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
     "server": "node server/index.js"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^9.4.1",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.1",
-    "express": "^4.19.2",
-    "better-sqlite3": "^9.4.1",
-    "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.2"
+    "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -35,8 +36,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
-    ,
+    "vite": "^5.4.2",
     "vitest": "^1.0.0"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -2,8 +2,10 @@ import express from 'express';
 import Database from 'better-sqlite3';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import cors from 'cors';
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 
 const db = new Database('data.sqlite');

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -29,7 +29,8 @@ export const LoginPage: React.FC = () => {
 
     setError('');
     setLoading(true);
-    const endpoint = isLogin ? '/api/login' : '/api/register';
+    const apiUrl = import.meta.env.VITE_API_URL || '/api';
+    const endpoint = isLogin ? `${apiUrl}/login` : `${apiUrl}/register`;
     const payload = isLogin
       ? { email, password }
       : { email, password, username };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: { proxy: { '/api': 'http://localhost:3001' } },
 });


### PR DESCRIPTION
## Summary
- allow cross-origin requests with cors middleware
- proxy `/api` requests to backend via Vite dev server
- use `VITE_API_URL` for login/register endpoints

## Testing
- `npm test`
- `npm run lint`
- `npm run server` *(fails: Cannot find package 'cors')*


------
https://chatgpt.com/codex/tasks/task_e_6898ee9dc74083238fc8d150b45998e4