### PR TITLE
Add customizable user profile page

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -60,10 +60,10 @@ export const Header: React.FC = () => {
                   <span>{gameState.speedCoins.toLocaleString()} SC</span>
                 </div>
 
-                <div className="flex items-center text-white">
+                <Link to={`/profile/${gameState.user?.id}`} className="flex items-center text-white hover:underline">
                   <User className="w-5 h-5 mr-2" />
                   <span className="font-medium">{gameState.user?.username}</span>
-                </div>
+                </Link>
 
                 <button
                   onClick={logout}

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -1,0 +1,121 @@
+import React, { useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { useGameStateContext } from '../../hooks/useGameState';
+import { bannerOptions } from '../../data/banners';
+import { Button } from '../ui/Button';
+
+export const ProfilePage: React.FC = () => {
+  const { id } = useParams();
+  const { gameState, updateUserProfile } = useGameStateContext();
+  const user = gameState.user;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  if (!user || user.id !== id) {
+    return <div className="text-white p-8">Profil introuvable</div>;
+  }
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        updateUserProfile({ avatarUrl: reader.result as string });
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleBannerSelect = (url: string) => {
+    updateUserProfile({ bannerUrl: url });
+  };
+
+  const topCards = [...gameState.userCards]
+    .sort((a, b) => b.price - a.price)
+    .slice(0, 3);
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="relative h-48 bg-gray-700">
+        {user.bannerUrl && (
+          <img src={user.bannerUrl} alt="Bannière" className="w-full h-full object-cover" />
+        )}
+        <div className="absolute top-2 right-2 flex space-x-2">
+          {bannerOptions.map((url) => (
+            <button
+              key={url}
+              onClick={() => handleBannerSelect(url)}
+              className="w-10 h-10 rounded overflow-hidden border-2 border-white"
+            >
+              <img src={url} alt="Banner option" className="w-full h-full object-cover" />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4">
+        <div className="relative flex items-end">
+          <div className="relative -mt-16">
+            <div className="w-32 h-32 rounded-full overflow-hidden border-4 border-white">
+              {user.avatarUrl ? (
+                <img src={user.avatarUrl} alt="Avatar" className="w-full h-full object-cover" />
+              ) : (
+                <div className="w-full h-full bg-gray-500" />
+              )}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleAvatarChange}
+            />
+            <Button
+              size="sm"
+              className="absolute bottom-0 right-0 translate-y-1/2"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Changer
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <h2 className="text-2xl font-bold">{user.username}</h2>
+          <textarea
+            value={user.bio || ''}
+            onChange={(e) => updateUserProfile({ bio: e.target.value })}
+            placeholder="Ajoutez une biographie"
+            className="w-full mt-2 p-2 bg-black/30 rounded"
+          />
+          <p className="mt-2 text-sm text-gray-300">
+            Compte créé le {new Date(user.registrationDate).toLocaleDateString('fr-FR')}
+          </p>
+          <p className="mt-1 text-sm text-gray-300">
+            Nombre de cartes : {gameState.userCards.length}
+          </p>
+        </div>
+
+        <div className="mt-8">
+          <h3 className="text-xl font-semibold mb-4">Top 3 cartes les plus chères</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {topCards.map((card) => (
+              <div key={card.id} className="bg-black/30 p-4 rounded">
+                <img src={card.imageUrl} alt={card.name} className="w-full h-32 object-cover rounded" />
+                <div className="mt-2 text-center">
+                  <p className="font-medium text-sm">{card.name}</p>
+                  <p className="text-xs text-gray-300">{card.price} SC</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-8 text-center">
+          <Button>Échanger</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -13,6 +13,7 @@ interface GameStateContextType {
   updateSpeedCoins: (amount: number) => void;
   addCards: (cards: Card[]) => void;
   removeCard: (cardId: string) => void;
+  updateUserProfile: (data: Partial<Pick<User, 'bio' | 'avatarUrl' | 'bannerUrl'>>) => void;
   unlockAchievement: (id: string, type?: 'daily' | 'normal') => void;
   claimAchievementReward: (id: string, type?: 'daily' | 'normal') => void;
   resetDailyChallenges: () => void;
@@ -117,7 +118,7 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     localStorage.setItem('authToken', token);
     setGameState(prev => ({
       ...prev,
-      user,
+      user: { ...user, bio: user.bio || '', avatarUrl: user.avatarUrl || '', bannerUrl: user.bannerUrl || '' },
       speedCoins: user.speedCoins,
       userCards: sampleCards,
       packsOpened: 0,
@@ -160,6 +161,13 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     setGameState(prev => ({
       ...prev,
       userCards: prev.userCards.filter(card => card.id !== cardId)
+    }));
+  };
+
+  const updateUserProfile = (data: Partial<Pick<User, 'bio' | 'avatarUrl' | 'bannerUrl'>>) => {
+    setGameState(prev => ({
+      ...prev,
+      user: prev.user ? { ...prev.user, ...data } : null
     }));
   };
 
@@ -291,6 +299,7 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       updateSpeedCoins,
       addCards,
       removeCard,
+      updateUserProfile,
       unlockAchievement,
       claimAchievementReward,
       resetDailyChallenges,

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -1,0 +1,5 @@
+export const bannerOptions = [
+  'https://images.pexels.com/photos/417074/pexels-photo-417074.jpeg?auto=compress&cs=tinysrgb&w=1600',
+  'https://images.pexels.com/photos/120049/pexels-photo-120049.jpeg?auto=compress&cs=tinysrgb&w=1600',
+  'https://images.pexels.com/photos/127162/pexels-photo-127162.jpeg?auto=compress&cs=tinysrgb&w=1600'
+];

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -5,7 +5,7 @@ export const mockUser: User = {
   username: 'SpeedRacer',
   email: 'speedracer@f1cards.com',
   speedCoins: 50000,
-  registrationDate: new Date('2024-01-15')
+  registrationDate: new Date('2024-01-15').toISOString()
 };
 
 export const sampleCards: Card[] = [

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import { ShopPage } from './components/pages/ShopPage';
 import { MarketplacePage } from './components/pages/MarketplacePage';
 import { CardDetailsPage } from './components/pages/CardDetailsPage';
 import AchievementsPanel from './components/pages/AchievementsPanel';
+import ProfilePage from './components/pages/ProfilePage';
 
 export const AppRouter: React.FC = () => (
   <BrowserRouter>
@@ -22,6 +23,7 @@ export const AppRouter: React.FC = () => (
       <Route path="/shop" element={<ShopPage />} />
       <Route path="/marketplace" element={<MarketplacePage />} />
       <Route path="/card/:id" element={<CardDetailsPage />} />
+      <Route path="/profile/:id" element={<ProfilePage />} />
     </Routes>
   </BrowserRouter>
 );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,10 @@ export interface User {
   username: string;
   email: string;
   speedCoins: number;
-  registrationDate: Date;
+  registrationDate: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  bio?: string;
 }
 
 export interface Card {


### PR DESCRIPTION
## Summary
- add profile route and header link
- allow avatar, banner and bio updates via GameState context
- implement user profile with stats and top card display

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899081d7c588323840143027951d119