### PR TITLE
Use username in profile URLs

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -60,7 +60,7 @@ export const Header: React.FC = () => {
                   <span>{gameState.speedCoins.toLocaleString()} SC</span>
                 </div>
 
-                <Link to={`/profile/${gameState.user?.id}`} className="flex items-center text-white hover:underline">
+                <Link to={`/profile/${gameState.user?.username}`} className="flex items-center text-white hover:underline">
                   <User className="w-5 h-5 mr-2" />
                   <span className="font-medium">{gameState.user?.username}</span>
                 </Link>

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -5,12 +5,12 @@ import { bannerOptions } from '../../data/banners';
 import { Button } from '../ui/Button';
 
 export const ProfilePage: React.FC = () => {
-  const { id } = useParams();
+  const { username } = useParams();
   const { gameState, updateUserProfile } = useGameStateContext();
   const user = gameState.user;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  if (!user || user.id !== id) {
+  if (!user || user.username !== username) {
     return <div className="text-white p-8">Profil introuvable</div>;
   }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -23,7 +23,7 @@ export const AppRouter: React.FC = () => (
       <Route path="/shop" element={<ShopPage />} />
       <Route path="/marketplace" element={<MarketplacePage />} />
       <Route path="/card/:id" element={<CardDetailsPage />} />
-      <Route path="/profile/:id" element={<ProfilePage />} />
+      <Route path="/profile/:username" element={<ProfilePage />} />
     </Routes>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- route `/profile` now uses username parameter instead of numeric id
- update header link to point to user's username
- ensure profile page verifies route parameter against username

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68990ea221ec8323b2e3dbbe2561240b