### PR TITLE
Persist user profile updates and reload from database

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -98,6 +98,33 @@ const authMiddleware = (req, res, next) => {
   }
 };
 
+app.get('/api/profile', authMiddleware, (req, res) => {
+  try {
+    const row = db
+      .prepare(
+        'SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = ?'
+      )
+      .get(req.userId);
+    if (!row) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    const user = {
+      id: String(row.id),
+      username: row.username,
+      email: row.email,
+      speedCoins: row.speedCoins,
+      registrationDate: row.registrationDate,
+      avatarUrl: row.avatarUrl || '',
+      bannerUrl: row.bannerUrl || '',
+      bio: row.bio || '',
+    };
+    res.json({ user });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
 app.put('/api/profile', authMiddleware, (req, res) => {
   const { avatarUrl = '', bannerUrl = '', bio = '' } = req.body;
   try {

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -71,6 +71,40 @@ export const GameStateProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   }, []);
 
   useEffect(() => {
+    const token = localStorage.getItem('authToken');
+    if (token && !gameState.user) {
+      const fetchProfile = async () => {
+        try {
+          const apiUrl = import.meta.env.VITE_API_URL || '/api';
+          const res = await fetch(`${apiUrl}/profile`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (res.ok) {
+            const data = await res.json();
+            setGameState(prev => ({
+              ...prev,
+              user: data.user
+                ? {
+                    ...data.user,
+                    bio: data.user.bio || '',
+                    avatarUrl: data.user.avatarUrl || '',
+                    bannerUrl: data.user.bannerUrl || '',
+                  }
+                : prev.user,
+              speedCoins: data.user ? data.user.speedCoins : prev.speedCoins,
+              isAuthenticated: true,
+              token,
+            }));
+          }
+        } catch (err) {
+          console.error('Failed to fetch profile', err);
+        }
+      };
+      fetchProfile();
+    }
+  }, [gameState.user]);
+
+  useEffect(() => {
     localStorage.setItem('f1-game-state', JSON.stringify(gameState));
   }, [gameState]);
 


### PR DESCRIPTION
## Summary
- add `/api/profile` GET endpoint to fetch stored profile details from SQLite
- load profile from backend on startup when auth token exists to retain avatar, banner, and bio after relogin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a9c732ec8323bf5d6a13ab7562b2