### PR TITLE
Add JWT secret env requirement and dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ cd F1-Card-Collection
 npm install
 ```
 
+### Configuration
+
+Avant de démarrer le serveur, vous devez définir la variable d'environnement `JWT_SECRET` utilisée pour signer les jetons JWT.
+Par exemple :
+
+```bash
+export JWT_SECRET=mon-super-secret
+npm run server
+```
+
 ## Scripts
 
 - `npm run dev` : démarre un serveur de développement avec rechargement à chaud.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
+    "dotenv": "^16.4.5",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,11 @@
+import dotenv from 'dotenv';
 import express from 'express';
 import Database from 'better-sqlite3';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import cors from 'cors';
+
+dotenv.config();
 
 const app = express();
 app.use(cors());
@@ -26,7 +29,10 @@ try { db.prepare('ALTER TABLE users ADD COLUMN avatarUrl TEXT').run(); } catch {
 try { db.prepare('ALTER TABLE users ADD COLUMN bannerUrl TEXT').run(); } catch {}
 try { db.prepare('ALTER TABLE users ADD COLUMN bio TEXT').run(); } catch {}
 
-const JWT_SECRET = process.env.JWT_SECRET || 'changeme';
+const { JWT_SECRET } = process.env;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 
 app.post('/api/register', async (req, res) => {
   const { username, email, password, avatarUrl = '', bannerUrl = '', bio = '' } = req.body;


### PR DESCRIPTION
## Summary
- load environment variables with dotenv in server
- throw error when JWT_SECRET is not defined
- document JWT_SECRET requirement and add dependency

## Testing
- `npm test run`


------
https://chatgpt.com/codex/tasks/task_e_6899b63cb5ac83238bccb3db1d3f5b65