### PR TITLE
Add CORS allowed origins configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ npm install
 
 ### Configuration
 
-Avant de démarrer le serveur, vous devez définir la variable d'environnement `JWT_SECRET` utilisée pour signer les jetons JWT.
-Par exemple :
+Avant de démarrer le serveur, vous devez définir certaines variables d'environnement :
 
 ```bash
 export JWT_SECRET=mon-super-secret
+export ALLOWED_ORIGINS=https://exemple.com,http://localhost:5173
 npm run server
 ```
+
+`ALLOWED_ORIGINS` définit la liste des origines autorisées par CORS (séparées par des virgules).
+Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
 
 ## Scripts
 

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,21 @@ import cors from 'cors';
 dotenv.config();
 
 const app = express();
-app.use(cors());
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
+  : ['http://localhost:5173'];
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+  })
+);
 app.use(express.json());
 
 const db = new Database('data.sqlite');


### PR DESCRIPTION
## Summary
- Configure CORS middleware to read allowed origins from `ALLOWED_ORIGINS` env variable with fallback to `http://localhost:5173`
- Document `ALLOWED_ORIGINS` usage in deployment instructions

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6899b80f3ad48323981f9d58fd5e4421