### PR TITLE
feat: make database path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Avant de démarrer le serveur, vous devez définir certaines variables d'environ
 ```bash
 export JWT_SECRET=mon-super-secret
 export ALLOWED_ORIGINS=https://exemple.com,http://localhost:5173
+export DB_PATH=/var/lib/f1-card-collection/data.sqlite
 npm run server
 ```
 
 `ALLOWED_ORIGINS` définit la liste des origines autorisées par CORS (séparées par des virgules).
 Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
+
+`DB_PATH` définit le chemin du fichier SQLite. Il vaut `data.sqlite` par défaut et doit pointer vers un emplacement persistant en production, par exemple `/var/lib/f1-card-collection/data.sqlite`.
 
 ## Scripts
 

--- a/server/index.js
+++ b/server/index.js
@@ -25,7 +25,8 @@ app.use(
 );
 app.use(express.json());
 
-const db = new Database('data.sqlite');
+const DB_PATH = process.env.DB_PATH || 'data.sqlite';
+const db = new Database(DB_PATH);
 
 db.exec(`CREATE TABLE IF NOT EXISTS users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- allow overriding SQLite path via `DB_PATH` env variable
- document `DB_PATH` and recommended production location

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6899bb383b388323b256ceaada1c3ab3