### PR TITLE
feat: add production start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
 - `npm run dev` : démarre un serveur de développement avec rechargement à chaud.
 - `npm run build` : génère la version de production dans le dossier `dist/`.
 - `npm run preview` : lance un serveur pour prévisualiser la version de production.
+- `npm start` : lance le serveur en production.
 - `npm test` : exécute les tests unitaires avec Vitest.
 
 ## Contribuer

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
+    "start": "node server/index.js",
     "server": "node server/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add npm start script for production server
- document `npm start` usage in README

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899bcc40f04832387f46b1473925f4d