### PR TITLE
Serve built frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,21 @@ Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
 - `npm run dev` : démarre un serveur de développement avec rechargement à chaud.
 - `npm run build` : génère la version de production dans le dossier `dist/`.
 - `npm run preview` : lance un serveur pour prévisualiser la version de production.
-- `npm start` : lance le serveur en production.
+- `npm start` : exécute `npm run build` puis lance le serveur qui sert `dist/`.
 - `npm test` : exécute les tests unitaires avec Vitest.
+
+## Déploiement sur un même hébergeur
+
+Le serveur Express sert les fichiers statiques générés dans `dist/` et renvoie
+`index.html` pour toute route non API. Pour un déploiement sur un même
+hébergeur, exécutez simplement :
+
+```bash
+npm start
+```
+
+Cette commande compile le frontend (`npm run build`) puis démarre le serveur en
+production.
 
 ## Contribuer
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "start": "node server/index.js",
+    "start": "npm run build && node server/index.js",
     "server": "node server/index.js"
   },
   "dependencies": {

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ import Database from 'better-sqlite3';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import cors from 'cors';
+import path from 'path';
 
 dotenv.config();
 
@@ -24,6 +25,7 @@ app.use(
   })
 );
 app.use(express.json());
+app.use(express.static('dist'));
 
 const DB_PATH = process.env.DB_PATH || 'data.sqlite';
 const db = new Database(DB_PATH);
@@ -173,6 +175,10 @@ app.put('/api/profile', authMiddleware, (req, res) => {
     console.error(err);
     res.status(500).json({ message: 'Server error' });
   }
+});
+
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve('dist/index.html'));
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- serve dist/ as static assets and return index.html for client-side routes
- run build automatically before starting production server
- document combined frontend/server deployment instructions

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899be5127b483238ca1af5f1834f67f