### PR TITLE
Add .env example with documented variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Secret utilisé pour signer les JWT
+JWT_SECRET=
+
+# Liste d'origines autorisées par CORS (séparées par des virgules)
+ALLOWED_ORIGINS=
+
+# Chemin vers le fichier SQLite
+DB_PATH=
+
+# Port d'écoute du serveur HTTP
+PORT=

--- a/README.md
+++ b/README.md
@@ -23,13 +23,18 @@ Avant de démarrer le serveur, vous devez définir certaines variables d'environ
 export JWT_SECRET=mon-super-secret
 export ALLOWED_ORIGINS=https://exemple.com,http://localhost:5173
 export DB_PATH=/var/lib/f1-card-collection/data.sqlite
+export PORT=3000
 npm run server
 ```
+
+`JWT_SECRET` est le secret utilisé pour signer les tokens JWT.
 
 `ALLOWED_ORIGINS` définit la liste des origines autorisées par CORS (séparées par des virgules).
 Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
 
 `DB_PATH` définit le chemin du fichier SQLite. Il vaut `data.sqlite` par défaut et doit pointer vers un emplacement persistant en production, par exemple `/var/lib/f1-card-collection/data.sqlite`.
+
+`PORT` définit le port d'écoute du serveur. La valeur par défaut est `3000`.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary
- add `.env.example` skeleton for JWT, CORS origins, DB path and server port
- document each environment variable in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6899ce9581548323934049bbf0250e2c