### PR TITLE
feat: add DATABASE_URL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -27,24 +27,44 @@ app.use(
 app.use(express.json());
 app.use(express.static('dist'));
 
+const DATABASE_URL = process.env.DATABASE_URL;
 const DB_PATH = process.env.DB_PATH || 'data.sqlite';
-const db = new Database(DB_PATH);
 
-db.exec(`CREATE TABLE IF NOT EXISTS users (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  username TEXT UNIQUE,
-  email TEXT UNIQUE,
-  password TEXT NOT NULL,
-  speedCoins INTEGER DEFAULT 0,
-  registrationDate TEXT,
-  avatarUrl TEXT,
-  bannerUrl TEXT,
-  bio TEXT
-)`);
+let db;
+const usePostgres = Boolean(DATABASE_URL);
 
-try { db.prepare('ALTER TABLE users ADD COLUMN avatarUrl TEXT').run(); } catch {}
-try { db.prepare('ALTER TABLE users ADD COLUMN bannerUrl TEXT').run(); } catch {}
-try { db.prepare('ALTER TABLE users ADD COLUMN bio TEXT').run(); } catch {}
+if (usePostgres) {
+  const pg = await import('pg');
+  const { Pool } = pg;
+  db = new Pool({ connectionString: DATABASE_URL });
+  await db.query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username TEXT UNIQUE,
+    email TEXT UNIQUE,
+    password TEXT NOT NULL,
+    speedCoins INTEGER DEFAULT 0,
+    registrationDate TEXT,
+    avatarUrl TEXT,
+    bannerUrl TEXT,
+    bio TEXT
+  )`);
+} else {
+  db = new Database(DB_PATH);
+  db.exec(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    email TEXT UNIQUE,
+    password TEXT NOT NULL,
+    speedCoins INTEGER DEFAULT 0,
+    registrationDate TEXT,
+    avatarUrl TEXT,
+    bannerUrl TEXT,
+    bio TEXT
+  )`);
+  try { db.prepare('ALTER TABLE users ADD COLUMN avatarUrl TEXT').run(); } catch {}
+  try { db.prepare('ALTER TABLE users ADD COLUMN bannerUrl TEXT').run(); } catch {}
+  try { db.prepare('ALTER TABLE users ADD COLUMN bio TEXT').run(); } catch {}
+}
 
 const { JWT_SECRET } = process.env;
 if (!JWT_SECRET) {
@@ -57,17 +77,42 @@ app.post('/api/register', async (req, res) => {
     return res.status(400).json({ message: 'Missing fields' });
   }
   try {
-    const existing = db.prepare('SELECT id FROM users WHERE email = ? OR username = ?').get(email, username);
-    if (existing) {
-      return res.status(400).json({ message: 'User already exists' });
+    if (usePostgres) {
+      const existing = await db.query('SELECT id FROM users WHERE email = $1 OR username = $2', [email, username]);
+      if (existing.rows.length > 0) {
+        return res.status(400).json({ message: 'User already exists' });
+      }
+      const hashed = await bcrypt.hash(password, 10);
+      const registrationDate = new Date().toISOString();
+      const result = await db.query(
+        'INSERT INTO users (username, email, password, speedCoins, registrationDate, avatarUrl, bannerUrl, bio) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id',
+        [username, email, hashed, 0, registrationDate, avatarUrl, bannerUrl, bio]
+      );
+      const user = {
+        id: String(result.rows[0].id),
+        username,
+        email,
+        speedCoins: 0,
+        registrationDate,
+        avatarUrl,
+        bannerUrl,
+        bio,
+      };
+      const token = jwt.sign({ id: user.id }, JWT_SECRET, { expiresIn: '1h' });
+      res.json({ token, user });
+    } else {
+      const existing = db.prepare('SELECT id FROM users WHERE email = ? OR username = ?').get(email, username);
+      if (existing) {
+        return res.status(400).json({ message: 'User already exists' });
+      }
+      const hashed = await bcrypt.hash(password, 10);
+      const registrationDate = new Date().toISOString();
+      const stmt = db.prepare('INSERT INTO users (username, email, password, speedCoins, registrationDate, avatarUrl, bannerUrl, bio) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+      const info = stmt.run(username, email, hashed, 0, registrationDate, avatarUrl, bannerUrl, bio);
+      const user = { id: String(info.lastInsertRowid), username, email, speedCoins: 0, registrationDate, avatarUrl, bannerUrl, bio };
+      const token = jwt.sign({ id: user.id }, JWT_SECRET, { expiresIn: '1h' });
+      res.json({ token, user });
     }
-    const hashed = await bcrypt.hash(password, 10);
-    const registrationDate = new Date().toISOString();
-    const stmt = db.prepare('INSERT INTO users (username, email, password, speedCoins, registrationDate, avatarUrl, bannerUrl, bio) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
-    const info = stmt.run(username, email, hashed, 0, registrationDate, avatarUrl, bannerUrl, bio);
-    const user = { id: String(info.lastInsertRowid), username, email, speedCoins: 0, registrationDate, avatarUrl, bannerUrl, bio };
-    const token = jwt.sign({ id: user.id }, JWT_SECRET, { expiresIn: '1h' });
-    res.json({ token, user });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Server error' });
@@ -80,7 +125,13 @@ app.post('/api/login', async (req, res) => {
     return res.status(400).json({ message: 'Missing fields' });
   }
   try {
-    const row = db.prepare('SELECT * FROM users WHERE email = ?').get(email);
+    let row;
+    if (usePostgres) {
+      const result = await db.query('SELECT * FROM users WHERE email = $1', [email]);
+      row = result.rows[0];
+    } else {
+      row = db.prepare('SELECT * FROM users WHERE email = ?').get(email);
+    }
     if (!row) {
       return res.status(400).json({ message: 'Invalid credentials' });
     }
@@ -121,13 +172,22 @@ const authMiddleware = (req, res, next) => {
   }
 };
 
-app.get('/api/profile', authMiddleware, (req, res) => {
+app.get('/api/profile', authMiddleware, async (req, res) => {
   try {
-    const row = db
-      .prepare(
-        'SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = ?'
-      )
-      .get(req.userId);
+    let row;
+    if (usePostgres) {
+      const result = await db.query(
+        'SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = $1',
+        [req.userId]
+      );
+      row = result.rows[0];
+    } else {
+      row = db
+        .prepare(
+          'SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = ?'
+        )
+        .get(req.userId);
+    }
     if (!row) {
       return res.status(404).json({ message: 'User not found' });
     }
@@ -148,18 +208,33 @@ app.get('/api/profile', authMiddleware, (req, res) => {
   }
 });
 
-app.put('/api/profile', authMiddleware, (req, res) => {
+app.put('/api/profile', authMiddleware, async (req, res) => {
   const { avatarUrl = '', bannerUrl = '', bio = '' } = req.body;
   try {
-    db.prepare('UPDATE users SET avatarUrl = ?, bannerUrl = ?, bio = ? WHERE id = ?').run(
-      avatarUrl,
-      bannerUrl,
-      bio,
-      req.userId
-    );
-    const row = db
-      .prepare('SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = ?')
-      .get(req.userId);
+    let row;
+    if (usePostgres) {
+      await db.query('UPDATE users SET avatarUrl = $1, bannerUrl = $2, bio = $3 WHERE id = $4', [
+        avatarUrl,
+        bannerUrl,
+        bio,
+        req.userId,
+      ]);
+      const result = await db.query(
+        'SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = $1',
+        [req.userId]
+      );
+      row = result.rows[0];
+    } else {
+      db.prepare('UPDATE users SET avatarUrl = ?, bannerUrl = ?, bio = ? WHERE id = ?').run(
+        avatarUrl,
+        bannerUrl,
+        bio,
+        req.userId
+      );
+      row = db
+        .prepare('SELECT id, username, email, speedCoins, registrationDate, avatarUrl, bannerUrl, bio FROM users WHERE id = ?')
+        .get(req.userId);
+    }
     const user = {
       id: String(row.id),
       username: row.username,


### PR DESCRIPTION
## Summary
- allow configuring PostgreSQL via `DATABASE_URL`
- fall back to local SQLite when no URL is provided
- add `pg` dependency for optional Postgres support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d0ae0954832391f957226f28bb57