### PR TITLE
docs: clarify multiple CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Avant de démarrer le serveur, vous devez définir certaines variables d'environ
 
 ```bash
 export JWT_SECRET=mon-super-secret
-export ALLOWED_ORIGINS=https://exemple.com,http://localhost:5173
+export ALLOWED_ORIGINS="https://mon-domaine.com,https://admin.mon-domaine.com"
 export DB_PATH=/var/lib/f1-card-collection/data.sqlite
 export PORT=3000
 npm run server
@@ -30,6 +30,8 @@ npm run server
 `JWT_SECRET` est le secret utilisé pour signer les tokens JWT.
 
 `ALLOWED_ORIGINS` définit la liste des origines autorisées par CORS (séparées par des virgules).
+Pour autoriser plusieurs origines, séparez-les par des virgules, par exemple :
+`https://mon-domaine.com,https://admin.mon-domaine.com`.
 Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
 
 `DB_PATH` définit le chemin du fichier SQLite. Il vaut `data.sqlite` par défaut et doit pointer vers un emplacement persistant en production, par exemple `/var/lib/f1-card-collection/data.sqlite`.


### PR DESCRIPTION
## Summary
- detail how to configure several CORS origins via ALLOWED_ORIGINS
- add example `https://mon-domaine.com,https://admin.mon-domaine.com`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899d406e94c8323bde827b31e0c894e