### PR TITLE
Handle multiple ALLOWED_ORIGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Sur Hostinger, définissez les variables d'environnement depuis le panneau **Adv
 export ALLOWED_ORIGINS="https://f1cardcollection.mvcraft.fr"
 ```
 
+Pour autoriser plusieurs domaines, séparez-les par des virgules :
+
+```bash
+export ALLOWED_ORIGINS="https://f1cardcollection.mvcraft.fr,https://admin.f1cards.fr"
+```
+
 Les variables `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE`, `MYSQL_USER` et `MYSQL_PASSWORD` doivent correspondre aux paramètres de votre base MySQL Hostinger. Elles permettent au serveur de se connecter à la base pour stocker les utilisateurs.
 
 Avant de lancer l'application, créez la table `users` :

--- a/server/allowedOrigins.js
+++ b/server/allowedOrigins.js
@@ -1,0 +1,8 @@
+export function getAllowedOrigins(env = process.env.ALLOWED_ORIGINS) {
+  return env
+    ? env
+        .split(',')
+        .map((o) => o.trim())
+        .filter(Boolean)
+    : ['http://localhost:5173'];
+}

--- a/server/index.js
+++ b/server/index.js
@@ -5,13 +5,12 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import cors from 'cors';
 import path from 'path';
+import { getAllowedOrigins } from './allowedOrigins.js';
 
 dotenv.config();
 
 const app = express();
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
-  : ['http://localhost:5173'];
+const allowedOrigins = getAllowedOrigins();
 
 app.use(
   cors({

--- a/tests/allowedOrigins.test.ts
+++ b/tests/allowedOrigins.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { getAllowedOrigins } from '../server/allowedOrigins.js';
+
+describe('getAllowedOrigins', () => {
+  it('handles a single domain', () => {
+    expect(getAllowedOrigins('https://f1cardcollection.mvcraft.fr')).toEqual([
+      'https://f1cardcollection.mvcraft.fr',
+    ]);
+  });
+
+  it('handles multiple domains separated by commas', () => {
+    expect(
+      getAllowedOrigins(
+        'https://example.com,https://admin.example.com'
+      )
+    ).toEqual(['https://example.com', 'https://admin.example.com']);
+  });
+
+  it('trims spaces and ignores empty values', () => {
+    expect(
+      getAllowedOrigins(' https://a.com , https://b.com , ')
+    ).toEqual(['https://a.com', 'https://b.com']);
+  });
+
+  it('falls back to localhost when undefined', () => {
+    expect(getAllowedOrigins(undefined)).toEqual(['http://localhost:5173']);
+  });
+});


### PR DESCRIPTION
## Summary
- extract helper to parse ALLOWED_ORIGINS
- add tests for single and multiple CORS origins
- document adding extra origins in README

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a53b4524c83238c982cbb160665b6