### PR TITLE
Ensure build output included in deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+.DS_Store
+.git
+.gitignore
+Dockerfile
+
+# Build outputs
+build
+
+# We'll rebuild dist in the image
+/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/server ./server
+COPY --from=build /app/dist ./dist
+CMD ["node", "server/index.js"]

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,11 @@ const distPath = process.env.DIST_PATH
   ? path.resolve(process.env.DIST_PATH)
   : path.join(__dirname, '../dist');
 
+// Log the current working directory and the resolved dist path so we can
+// verify the server is serving the expected directory at runtime.
+console.log('Working directory:', process.cwd());
+console.log('Resolved dist path:', distPath);
+
 dotenv.config();
 
 const app = express();


### PR DESCRIPTION
## Summary
- log working directory and resolved dist path on server start
- add Dockerfile that builds the app and copies dist alongside the server
- add .dockerignore to trim Docker build context

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dea15c79883238a8e668a862e51ea