### PR TITLE
Load env vars before computing dist path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { getAllowedOrigins } from './allowedOrigins.js';
 
+dotenv.config();
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const distPath = process.env.DIST_PATH
@@ -18,8 +20,6 @@ const distPath = process.env.DIST_PATH
 // verify the server is serving the expected directory at runtime.
 console.log('Working directory:', process.cwd());
 console.log('Resolved dist path:', distPath);
-
-dotenv.config();
 
 const app = express();
 const allowedOrigins = getAllowedOrigins();


### PR DESCRIPTION
## Summary
- call dotenv.config() before accessing environment variables
- recompute distPath after loading env vars

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689def9554d0832393dc7f3116928aa7