### PR TITLE
Restrict CORS to API endpoints

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -25,17 +25,13 @@ console.log('Resolved dist path:', distPath);
 const app = express();
 const allowedOrigins = getAllowedOrigins();
 
-app.use(
-  cors({
-    origin: (origin, callback) => {
-      if (!origin || allowedOrigins.includes(origin)) {
-        callback(null, true);
-      } else {
-        callback(new Error('Not allowed by CORS'));
-      }
-    },
-  })
-);
+const corsOptions = {
+  origin: (origin, callback) =>
+    !origin || allowedOrigins.includes(origin)
+      ? callback(null, true)
+      : callback(new Error('Not allowed by CORS')),
+};
+app.use('/api', cors(corsOptions));
 app.use(express.json());
 app.use(express.static(distPath));
 


### PR DESCRIPTION
## Summary
- Limit CORS middleware to `/api` routes with explicit options
- Leave static assets unaffected by CORS

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*


------
https://chatgpt.com/codex/tasks/task_e_689e609f705c8323a5e08887fa6daf09