### PR TITLE
fix: update allowed origins default and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm run server
 
 `JWT_SECRET` est le secret utilisé pour signer les tokens JWT.
 
-`ALLOWED_ORIGINS` définit la liste des origines autorisées par CORS (séparées par des virgules). Pour autoriser plusieurs origines, séparez-les par des virgules, par exemple : `https://mon-domaine.com,https://admin.mon-domaine.com`. Si elle n'est pas définie, `http://localhost:5173` est utilisée par défaut.
+`ALLOWED_ORIGINS` définit la liste des origines autorisées par CORS (séparées par des virgules). Pour autoriser plusieurs origines, séparez-les par des virgules, par exemple : `https://mon-domaine.com,https://admin.mon-domaine.com`. Si elle n'est pas définie, `https://f1-card-collection.onrender.com` est utilisée par défaut. Pour éviter les erreurs de domaine, il est recommandé de définir explicitement `ALLOWED_ORIGINS` avec vos propres URLs.
 
 `MYSQL_HOST` spécifie l'hôte du serveur MySQL.
 

--- a/server/allowedOrigins.js
+++ b/server/allowedOrigins.js
@@ -4,5 +4,5 @@ export function getAllowedOrigins(env = process.env.ALLOWED_ORIGINS) {
         .split(',')
         .map((o) => o.trim())
         .filter(Boolean)
-    : ['https://f1-card-collection.onrender.co'];
+    : ['https://f1-card-collection.onrender.com'];
 }

--- a/tests/allowedOrigins.test.ts
+++ b/tests/allowedOrigins.test.ts
@@ -22,7 +22,9 @@ describe('getAllowedOrigins', () => {
     ).toEqual(['https://a.com', 'https://b.com']);
   });
 
-  it('falls back to localhost when undefined', () => {
-    expect(getAllowedOrigins(undefined)).toEqual(['http://localhost:5173']);
+  it('falls back to the default domain when undefined', () => {
+    expect(getAllowedOrigins(undefined)).toEqual([
+      'https://f1-card-collection.onrender.com',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- correct default allowed origin domain
- document ALLOWED_ORIGINS usage and fix related tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f11cfdfa48323a1372d678dc7af17