### PR TITLE
docs: use TEXT for user avatars and banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ CREATE TABLE IF NOT EXISTS users (
   password VARCHAR(255) NOT NULL,
   speedCoins INT DEFAULT 0,
   registrationDate VARCHAR(255),
-  avatarUrl VARCHAR(255),
-  bannerUrl VARCHAR(255),
+  avatarUrl TEXT,
+  bannerUrl TEXT,
   bio TEXT
 );
 ```


### PR DESCRIPTION
## Summary
- docs: use TEXT for user avatars and banners in users table example

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_689f27f3dfc48323b349a783e8f269eb