### PR TITLE
chore: add multer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "pg": "^8.11.3",
-    "mysql2": "^3.9.4"
+    "mysql2": "^3.9.4",
+    "multer": "^1.4.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- add multer to dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/multer)*
- `npm run server` *(fails: Cannot find package 'dotenv')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ed9c25c8323ad17cbe2dfd6b3b6